### PR TITLE
Improve AddRange implementation

### DIFF
--- a/ObservableCollectionExSampleApp/ObservableCollectionEx.cs
+++ b/ObservableCollectionExSampleApp/ObservableCollectionEx.cs
@@ -30,7 +30,7 @@ public class ObservableCollectionEx<T> : ObservableCollection<T>
                 OnCollectionChanged(
                     new NotifyCollectionChangedEventArgs(
                         action: NotifyCollectionChangedAction.Add,
-                        changedItems: collection.ToList(),
+                        changedItems: collection as System.Collections.IList ?? collection.ToList(),
                         startingIndex: Count - count));
             }
             else // count == 1 - single-item change

--- a/ObservableCollectionExSampleApp/ObservableCollectionEx.cs
+++ b/ObservableCollectionExSampleApp/ObservableCollectionEx.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Linq;
@@ -7,22 +7,40 @@ namespace ObservableCollectionExSampleApp;
 
 public class ObservableCollectionEx<T> : ObservableCollection<T>
 {
+    private readonly static System.ComponentModel.PropertyChangedEventArgs ItemsINPC = new System.ComponentModel.PropertyChangedEventArgs("Item[]");
+    private readonly static System.ComponentModel.PropertyChangedEventArgs CountINPC = new System.ComponentModel.PropertyChangedEventArgs(nameof(Count));
+
     public void AddRange(IEnumerable<T> collection)
     {
         CheckReentrancy();
 
-        if (collection.Any() is false)
+        int count = 0;
+        foreach (var item in collection)
         {
-            return;
+            count++;
+            base.Items.Add(item); // Editing this protected list won't raise events
         }
 
-        List<T> itemsList = (List<T>)Items;
-        itemsList.AddRange(collection);
-
-        OnCollectionChanged(
-            new NotifyCollectionChangedEventArgs(
-                action: NotifyCollectionChangedAction.Add,
-                changedItem: itemsList.Last(),
-                index: itemsList.Count - 1));
+        if(count > 0)
+        {
+            OnPropertyChanged(ItemsINPC);
+            OnPropertyChanged(CountINPC);
+            if (count > 1) // Multi-item change
+            {
+                OnCollectionChanged(
+                    new NotifyCollectionChangedEventArgs(
+                        action: NotifyCollectionChangedAction.Add,
+                        changedItems: collection.ToList(),
+                        startingIndex: Count - count));
+            }
+            else // count == 1 - single-item change
+            {
+                OnCollectionChanged(
+                new NotifyCollectionChangedEventArgs(
+                        action: NotifyCollectionChangedAction.Add,
+                        changedItem: collection.First(),
+                        index: Count - 1));
+            }
+        }
     }
 }

--- a/ObservableCollectionExSampleApp/ObservableCollectionEx.cs
+++ b/ObservableCollectionExSampleApp/ObservableCollectionEx.cs
@@ -36,7 +36,7 @@ public class ObservableCollectionEx<T> : ObservableCollection<T>
             else // count == 1 - single-item change
             {
                 OnCollectionChanged(
-                new NotifyCollectionChangedEventArgs(
+                    new NotifyCollectionChangedEventArgs(
                         action: NotifyCollectionChangedAction.Add,
                         changedItem: collection.First(),
                         index: Count - 1));


### PR DESCRIPTION
Avoid casts.
Correctly raise multi-item change event (must set `changedItems` with list of changes)
Ensure `Count` and `Item[]` properties are notified they change. See https://github.com/dotnet/runtime/blob/ef866615f9779f417103e9e8563d2201fe914b35/src/libraries/System.ObjectModel/src/System/Collections/ObjectModel/ObservableCollection.cs#L124-L125 for reference